### PR TITLE
(ios) デバイストークン登録処理の修正

### DIFF
--- a/src/ios/AppDelegate+NiftyCloud.h
+++ b/src/ios/AppDelegate+NiftyCloud.h
@@ -8,5 +8,5 @@
 #import <UserNotifications/UserNotifications.h>
 
 @interface AppDelegate (NiftyCloud) <UNUserNotificationCenterDelegate>
-
+- (void) registerForRemoteNotifications;
 @end

--- a/src/ios/NiftyPushNotification.m
+++ b/src/ios/NiftyPushNotification.m
@@ -3,6 +3,7 @@
 //  Copyright 2017 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
 //
 
+#import "AppDelegate+NiftyCloud.h"
 #import "NiftyPushNotification.h"
 #import "NCMB/NCMB.h"
 
@@ -245,6 +246,9 @@ static BOOL hasSetup = NO;
 
     if (deviceToken != nil) {
         [self performSelectorInBackground:@selector(saveInBackgroundWithBlockFirst:) withObject:deviceToken];
+    } else {
+        AppDelegate *delegate = (AppDelegate *)[UIApplication sharedApplication].delegate;
+        [delegate registerForRemoteNotifications];
     }
 }
 


### PR DESCRIPTION
## 概要(Summary)

■再現手順

1. アプリをインストールして起動する
2. プッシュ通知の許可の確認ダイアログで「許可しない」を選択
3. その後、プログラムでNCMB.monaca.setDeviceTokenを呼んでも何も起こらない (★NG)
4. OSの設定 > 通知 > 【アプリ】> 通知を許可をOKにする
5. アプリ側で再度NCMB.monaca.setDeviceTokenを呼んでも何も起こらない (★NG)
6. アプリを再起動すると登録される

## 変更内容 ##

* プッシュ通知の許可の確認ダイアログ表示を初回NCMB.monaca.setDeviceTokenを読んだタイミングで表示するように変更
    * 元々はアプリ起動時に強制的に呼ばれていた。任意(初回NCMB.monaca.setDeviceToken時)のタイミングに変更。
    * プッシュ通知の許可の確認ダイアログで「許可しない」を選択された後に、
OS設定で通知を許可にしてから、NCMB.monaca.setDeviceTokenを呼ばれた場合、
アプリを再起動しなくても登録処理がされるように、registerForRemoteNotificationsを呼ぶように改良

* プッシュ通知の許可の確認ダイアログで「許可しない」を選択された後に、
NCMB.monaca.setDeviceTokenを読んだ場合、エラーコールバックを呼ぶように修正。


## 動作確認手順(Step for Confirmation)

* 確認OS
    * iOS 11.2.5
    * iOS 10.3.3

1. アプリをインストールして起動する
2. プッシュ通知の許可の確認ダイアログで「許可しない」を選択
3. その後、プログラムでNCMB.monaca.setDeviceTokenを呼ぶとエラーコールバックが呼ばれること(★OK)
4. OSの設定 > 通知 > 【アプリ】> 通知を許可をOKにする
5. アプリ側で再度NCMB.monaca.setDeviceTokenを呼ぶと、トークンが登録されること(★OK)