### PR TITLE
(android) play-services全体でなく、必要なplay-services-gcmのみを指定

### DIFF
--- a/ncmb.gradle
+++ b/ncmb.gradle
@@ -6,7 +6,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.android.gms:play-services:11.0.0'
+    compile 'com.google.android.gms:play-services-gcm:11.0.0'
     compile 'com.google.code.gson:gson:2.3.1'
     compile 'com.android.support:appcompat-v7:26.0.2'
 }

--- a/plugin.xml
+++ b/plugin.xml
@@ -63,7 +63,7 @@
             <meta-data android:name="notificationOverlap" android:value="1"/>
         </config-file>
         <framework src="ncmb.gradle" custom="true" type="gradleReference"/>
-        <framework src="com.google.android.gms:play-services:11.0.0" />
+        <framework src="com.google.android.gms:play-services-gcm:11.0.0" />
         <framework src="com.android.support:appcompat-v7:26.0.2" />
         <framework src="com.google.code.gson:gson:2.3.1" />
         <lib-file src="src/android/libs/NCMB.jar" />


### PR DESCRIPTION
## 概要(Summary)

(android) play-services全体でなく、必要なplay-services-gcmのみを指定

### 問題点
他plugin追加時(例えばcordova-hot-code-push-plugin)に
DexIndexOverflowExceptionが発生して、Multidex対応等が必要になる場合がある。

### 原因
com.google.android.gms:play-services への依存により、
約4万メソッドが追加されるため。

参考:
https://developers.google.com/android/guides/setup
> Note: Don't use the combined play-services target. It brings in dozens of libraries, bloating your application. Instead, specify only the specific Google Play services APIs your app uses.

### 対処
play-services全体でなく、必要なplay-services-gcmのみを指定

### 効果
ncmb-push-monaca-pluginのみをplugin addしてビルドした場合の比較。

比較            | メソッド数 | apkサイズ(Debug)| cordova build時間
---------------------|-------|-----------------|-------
play-services        | 63533 | 6,835,454 bytes | 2m 23s
play-services-gcmのみ| 24090 | 3,724,326 bytes | 1m  9s

(build時間はGPD Pocket(Atom Z8750)上)

メソッド数は、Android StudioでProfile or debug APKから開いて確認:
![pushtestall](https://user-images.githubusercontent.com/761487/35775002-338d970a-09c3-11e8-90ad-48a99d389242.png)
![onlygcm](https://user-images.githubusercontent.com/761487/35775004-3b841786-09c3-11e8-9dcf-208eb2a508a0.png)

### 備考
NCMB.jarのソースを確認して、必要なのが play-services-gcm のみであることを確認済。
(iid, commonはgcmの依存関係で入る)

```
NCMBGcmListenerService.java:import com.google.android.gms.gcm.GcmListenerService;
NCMBGcmReceiver.java:import com.google.android.gms.gcm.GcmReceiver;
NCMBInstallation.java:import com.google.android.gms.common.ConnectionResult;
NCMBInstallation.java:import com.google.android.gms.common.GooglePlayServicesUtil;
NCMBInstallation.java:import com.google.android.gms.gcm.GoogleCloudMessaging;
NCMBInstallation.java:import com.google.android.gms.iid.InstanceID;
```

```
gradlew :app:dependencies
...
+--- com.google.android.gms:play-services-gcm:11.0.0
|    +--- com.google.android.gms:play-services-base:[11.0.0] -> 11.0.0
...
|    +--- com.google.android.gms:play-services-basement:[11.0.0] -> 11.0.0 (*)
|    \--- com.google.android.gms:play-services-iid:[11.0.0] -> 11.0.0
...
```

### 再現手順
1. cordova create pushtest jp.example.pushtest pushtest
2. cd pushtest
3. cordova platform add android
4. cordova plugin add ncmb-push-monaca-plugin
5. cordova plugin add cordova-hot-code-push-plugin
6. cordova build

```
...
> java.lang.RuntimeException: java.lang.RuntimeException: com.android.builder.dexing.DexArchiveMergerException: Unable to merge dex
...
Caused by: com.android.dex.DexIndexOverflowException: method ID not in [0, 0xffff]: 65536
```

## 動作確認手順(Step for Confirmation)

cordova-hot-code-push-pluginをaddしても
DexIndexOverflowExceptionが発生しないこと:
1. cordova create pushtest jp.example.pushtest pushtest
2. cd pushtest
3. cordova platform add android
4. cordova plugin add ..\monaca_push_plugin
5. cordova plugin add cordova-hot-code-push-plugin
6. cordova build

また、Pushが受信できること:
1. スマホでサンプルHTMLを使ったアプリを実行
2. PCからNCMBコンソールを開いてPushを送信
3. スマホでPushが受信されること
