### PR TITLE
Feature/notification data

### DIFF
--- a/src/android/NcmbData.java
+++ b/src/android/NcmbData.java
@@ -3,6 +3,11 @@ package plugin.push.nifcloud;
 import android.content.Intent;
 import android.os.Bundle;
 
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.Set;
+
 /**
  * Ncmb push notification data holder.
  */
@@ -77,6 +82,20 @@ public class NcmbData {
      */
     public String getJson() {
         return mBundle.getString(JSON_KEY);
+    }
+
+    public JSONObject getAllData() {
+        JSONObject json = new JSONObject();
+        Set<String> keys = mBundle.keySet();
+        for (String key : keys) {
+            try {
+                json.put(key, mBundle.get(key));
+            } catch(JSONException e) {
+                e.printStackTrace();
+            }
+        }
+
+        return json;
     }
 
     /**

--- a/src/android/NcmbPushPlugin.java
+++ b/src/android/NcmbPushPlugin.java
@@ -144,6 +144,9 @@ public class NcmbPushPlugin extends CordovaPlugin
         } else {
             json = new JSONObject();
         }
+
+        json.put("_notification", data.getAllData());
+
         PluginResult result = new PluginResult(PluginResult.Status.OK, json);
         result.setKeepCallback(true);
         mPushReceivedCallbackContext.sendPluginResult(result);


### PR DESCRIPTION
## 概要(Summary)

Androidでもアプリ側でプッシュ通知のタイトルやメッセージを利用したいため、
プッシュ受信時のsetHandlerに渡ってくるJSONに、
notification全体を新たに、「_notification」キーにオブジェクトとして追加しました。
※iOSは「alert」のデータが含まれているので問題なし

## 動作確認手順(Step for Confirmation)

プッシュ通知を受信してjsonDataを確認ください。

```js
NCMB.monaca.setHandler(function(jsonData){
  alert("callback :::" + JSON.stringify(jsonData));
});
```
