### PR TITLE
update ios sdk v3.0.1

### DIFF
--- a/src/ios/NCMB/NCMBConstants.h
+++ b/src/ios/NCMB/NCMBConstants.h
@@ -22,7 +22,7 @@
 
 #pragma mark - error
 #define ERRORDOMAIN @"NCMBErrorDomain"
-#define SDK_VERSION @"3.0.2"
+#define SDK_VERSION @"3.0.1"
 
 #define DATA_MAIN_PATH [NSHomeDirectory() stringByAppendingPathComponent:@"Library/"]
 #define COMMAND_CACHE_FOLDER_PATH [NSString stringWithFormat:@"%@/Private Documents/NCMB/Command Cache/", DATA_MAIN_PATH]

--- a/src/ios/NCMB/NCMBRequest/NCMBRequest.h
+++ b/src/ios/NCMB/NCMBRequest/NCMBRequest.h
@@ -15,6 +15,7 @@
  */
 
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 @interface NCMBRequest : NSMutableURLRequest
 

--- a/src/ios/NCMB/NCMBRequest/NCMBRequest.m
+++ b/src/ios/NCMB/NCMBRequest/NCMBRequest.m
@@ -28,6 +28,8 @@ static NSString *const signatureField    = @"X-NCMB-Signature";
 static NSString *const sessionTokenField = @"X-NCMB-Apps-Session-Token";
 static NSString *const signatureMethod   = @"SignatureMethod=HmacSHA256";
 static NSString *const signatureVersion   = @"SignatureVersion=2";
+static NSString *const kSDKVersionFieldName = @"X-NCMB-SDK-Version";
+static NSString *const kOSVersionFieldName = @"X-NCMB-OS-Version";
 
 @implementation NCMBRequest
 
@@ -66,6 +68,11 @@ static NSString *const signatureVersion   = @"SignatureVersion=2";
     if ([method isEqualToString:@"POST"] || [method isEqualToString:@"PUT"]) {
         self.HTTPBody = bodyData;
     }
+    // Set SDK and OS version
+    NSString *osVersion = [[UIDevice currentDevice] systemVersion];
+    [self setValue:[NSString stringWithFormat:@"ios-%@", osVersion] forHTTPHeaderField:kOSVersionFieldName];
+    [self setValue:[NSString stringWithFormat:@"ios-%@", SDK_VERSION] forHTTPHeaderField:kSDKVersionFieldName];
+    
     return self;
 }
 

--- a/src/ios/NCMB/NCMBUser.m
+++ b/src/ios/NCMB/NCMBUser.m
@@ -948,7 +948,7 @@ static BOOL isEnableAutomaticUser = NO;
     if ([response objectForKey:@"sessionToken"]) {
         self.sessionToken = [response objectForKey:@"sessionToken"];
     }
-    [super afterFetch:response isRefresh:isRefresh];
+    [super afterFetch:response isRefresh:YES];
 }
 
 /**

--- a/src/ios/NCMB/NCMB_Info.plist
+++ b/src/ios/NCMB/NCMB_Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.0.2</string>
+	<string>3.0.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
## 概要(Summary)

- プラグインが利用する nifcloud mobile backend iOS sdk について、最新版(v3.0.1)に更新する