### PR TITLE
Fix issue #110: iosにて任意のタイミングでsetDeviceTokenを呼び出した際にinstallationの登録ができない

### DIFF
--- a/src/ios/AppDelegate+NifCloud.m
+++ b/src/ios/AppDelegate+NifCloud.m
@@ -55,7 +55,6 @@
         UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
         center.delegate = self;
     }
-    [self registerForRemoteNotifications];
 }
 
 - (void) registerForRemoteNotifications
@@ -121,6 +120,7 @@
     NcmbPushNotification *ncmb = [self getNcmbPushNotification];
     
     if (ncmb != nil) {
+        [ncmb setIsInitialStart];
         [ncmb setDeviceTokenAPNS:deviceToken];
     }
 }

--- a/src/ios/NcmbPushNotification.h
+++ b/src/ios/NcmbPushNotification.h
@@ -26,6 +26,7 @@
 - (void) failedToRegisterAPNS;
 - (void) addJson: (NSDictionary*)json withAppIsActive:(BOOL)isActive;
 - (void) sendAllJsons;
+- (void) setIsInitialStart;
 
 // call from JS
 - (void) setDeviceToken: (CDVInvokedUrlCommand*)command;

--- a/src/ios/NcmbPushNotification.m
+++ b/src/ios/NcmbPushNotification.m
@@ -23,6 +23,7 @@ static NSString* const kNcmbPushErrorCodeFailedToRegisterAPNS = @"EP000001";
 static NSString* const kNcmbPushErrorCodeInvalidParams        = @"EP000002";
 
 static BOOL hasSetup = NO;
+static BOOL _isInitialStart = YES;
 
 /**
  * Has device token (APNS) in storage or not.
@@ -156,6 +157,12 @@ static BOOL hasSetup = NO;
     [[NSUserDefaults standardUserDefaults] setObject:appKey forKey:kNcmbPushAppKey];
     [[NSUserDefaults standardUserDefaults] setObject:clientKey forKey:kNcmbPushClientKey];
     [[NSUserDefaults standardUserDefaults] synchronize];
+    
+    if (!_isInitialStart) {
+        [self installWithAppKey:appKey clientKey:clientKey deviceToken:[[self class] getDeviceTokenAPNS]];
+    } else {
+        [self installWithAppKey:appKey clientKey:clientKey deviceToken:nil];
+    }
 
     if (_isFailedToRegisterAPNS) {
         _isFailedToRegisterAPNS = NO;
@@ -230,6 +237,15 @@ static BOOL hasSetup = NO;
     } else {
         _isFailedToRegisterAPNS = YES;
     }
+}
+
+/**
+ * Set initial app is false
+ * This method make sure that the app initial is false.
+ *
+*/
+- (void) setIsInitialStart {
+    _isInitialStart = NO;
 }
 
 /**


### PR DESCRIPTION
## 概要(Summary)

- Fixed #110

## 動作確認手順(Step for Confirmation)

Call below code anywhere if you need.

function setDeviceTokenClick() {
    window.NCMB.monaca.setDeviceToken(
        APPLIVATION_KEY,
        CLIENT_KEY,
        successCallback,
        errorCallback
    );
}
