### PR TITLE
Update README.md to support cordova 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ---
 ## 動作環境
-- PhoneGap/Cordova 9.0, Cordova 10.0, Cordova 11.0, Cordova 12
+- PhoneGap/Cordova 9.0 ~ Cordova 12.0
 - iOSの対応環境：
   - iOS 13.x ~ iOS 16.x
 - Androidの対応環境：
@@ -169,7 +169,7 @@ LICENSEファイルをご覧ください。
 
 ## Specifications
 
-- PhoneGap/Cordova 9.0, Cordova 10.0, Cordova 11.0, Cordova 12.0
+- PhoneGap/Cordova 9.0 ~ Cordova 12.0
 - iOS Support OS version:
   - iOS 13.x ~ iOS 16.x
 - Android Support OS version:

--- a/README.md
+++ b/README.md
@@ -4,21 +4,21 @@
 
 ---
 ## 動作環境
-- PhoneGap/Cordova 9.0, Cordova 10.0, Cordova 11.0
+- PhoneGap/Cordova 9.0, Cordova 10.0, Cordova 11.0, Cordova 12
 - iOSの対応環境：
   - iOS 13.x ~ iOS 16.x
 - Androidの対応環境：
 
 | Android | Android APIレベル | NIFCLOUDMB<br>(ncmb-push-monaca-plugin) | Cordova  | ビルド環境設定        | その他                                                                      |
 |:-------:|:--------------:|:---------------------------------------:|:--------:|------------------|---------------------------------------------------------------------------|
-|  13.x   |       33       |               v3.2.0以上                | 12.0以上 | Android 12.0.0以上 | ※1                                                                          |
+|  13.x   |       33       |               v3.2.0以上                | 12.0以上 | Android 12.0.0以上 |                                                                         |
 |  12.x   |       32       |               v3.1.2以上                | 11.0以上 | Android 10.1.2以上 |                                                                           |
 |  12.0   |       31       |               v3.1.2以上                | 11.0以上 | Android 10.1.2以上 |                                                                           |
 |  11.0   |       30       |               v3.1.0以上                | 10.0以上 | Android 10.1.1以上 | Monaca IDEの設定で、「Androidアプリの設定」から「AndroidXを有効にする」にチェックを入れる必要があります |
 |  10.0   |       29       |               v3.1.0以上                | 10.0以上 | Android 10.1.1以上 | ^ 上に同じ                                                                  |
 
 ※ 併せて、[Monaca 対応環境](https://ja.docs.monaca.io/environment)をご確認ください。（NIFCLOUDMB (ncmb-push-monaca-plugin)の保証動作環境ではありません。）
-※1 Android 13向けのプッシュ通知がCordova12を利用して行えることを確認しているものであり、Cordova12の提供する全ての機能との互換性を保証するものではありません。
+
 
 ### テクニカルサポート窓口対応バージョン
 
@@ -169,14 +169,14 @@ LICENSEファイルをご覧ください。
 
 ## Specifications
 
-- PhoneGap/Cordova 9.0, Cordova 10.0, Cordova 11.0
+- PhoneGap/Cordova 9.0, Cordova 10.0, Cordova 11.0, Cordova 12.0
 - iOS Support OS version:
   - iOS 13.x ~ iOS 16.x
 - Android Support OS version:
 
 | Android | Android API level | NIFCLOUDMB<br>(ncmb-push-monaca-plugin) | Cordova | Build Environment Settings | Note                                                                                          |
 |:-------:|:-----------------:|:---------------------------------------:|:-------:|----------------------------|-----------------------------------------------------------------------------------------------|
-|  13.x   |        33         |                v3.2.0 ~                 | 12.0 ~  | Android 12.0.0 ~           | ※1                                                                                           |
+|  13.x   |        33         |                v3.2.0 ~                 | 12.0 ~  | Android 12.0.0 ~           |                                                                                            |
 |  12.x   |        32         |                v3.1.2 ~                 | 11.0 ~  | Android 10.1.2 ~           |                                                                                               |
 |  12.0   |        31         |                v3.1.2 ~                 | 11.0 ~  | Android 10.1.2 ~           |                                                                                               |
 |  11.0   |        30         |                v3.1.0 ~                 | 10.0 ~  | Android 10.1.1 ~           | Be sure to check the "Enable AndroidX" box in  "Android App Settings" on Monaca IDE settings. |
@@ -184,7 +184,7 @@ LICENSEファイルをご覧ください。
 
 
 ※  For reference, please check [Monaca Supported Environment](https://ja.docs.monaca.io/environment) （Notice: This is not an equal guarantee operation environment for the NIFCLOUDMB push plugin. ）
-※1 We only confirm that push notifications can be sent for Android 13 with Cordova 12. This is not guarantee compatibility with all features provided by Cordova 12.
+
 
 ## Support desk coverage version
 


### PR DESCRIPTION
## 概要(Summary)

- Cordova12のサポート環境に追加
- 参考： [monacaの対応環境](https://ja.docs.monaca.io/environment) に合わせて、Cordova 9.0~12.0サポート

## 動作確認手順(Step for Confirmation)

Run the unit test.
