### PR TITLE
Add publish npm workflow

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -1,9 +1,8 @@
 name: Publish package monaca_push_plugin
 
 on:
-  push:
-    branches:
-      - add_npm_flow
+  release:
+    types: [published]
 
 jobs:
   build:
@@ -15,6 +14,6 @@ jobs:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org/'
       - run: npm install
-      - run: npm pack --dry-run
+      - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -1,8 +1,9 @@
 name: Publish package monaca_push_plugin
 
 on:
-  release:
-    types: [published]
+  push:
+    branches:
+      - add_npm_flow
 
 jobs:
   build:
@@ -14,7 +15,6 @@ jobs:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org/'
       - run: npm install
-      - run: npm ci
-      - run: npm publish
+      - run: npm pack --dry-run
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -16,7 +16,6 @@ jobs:
           registry-url: 'https://registry.npmjs.org/'
       - run: npm install
       - run: npm ci
-      - run: npm test
       - run: npm pack --dry-run
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -14,6 +14,7 @@ jobs:
         with:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org/'
+      - run: npm install
       - run: npm ci
       - run: npm test
       - run: npm pack --dry-run

--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -1,8 +1,9 @@
 name: Publish package monaca_push_plugin
 
 on:
-  release:
-    types: [published]
+  push:
+    branches:
+      - add_npm_flow
 
 jobs:
   build:
@@ -15,6 +16,6 @@ jobs:
           registry-url: 'https://registry.npmjs.org/'
       - run: npm ci
       - run: npm test
-      - run: npm publish
+      - run: npm pack --dry-run
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -1,9 +1,8 @@
 name: Publish package monaca_push_plugin
 
 on:
-  push:
-    branches:
-      - add_npm_flow
+  release:
+    types: [published]
 
 jobs:
   build:
@@ -16,6 +15,6 @@ jobs:
           registry-url: 'https://registry.npmjs.org/'
       - run: npm install
       - run: npm ci
-      - run: npm pack --dry-run
+      - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -1,0 +1,20 @@
+name: Publish package monaca_push_plugin
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org/'
+      - run: npm ci
+      - run: npm test
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}


### PR DESCRIPTION
## 概要(Summary)

- npm公開作業を自動化する

## 動作確認手順(Step for Confirmation)

- Run the unit test.
- 動作テストするために、`npm publish` ではなく `npm pack --dry-run`  を実施した結果
  - https://github.com/NIFCLOUD-mbaas/monaca_push_plugin/actions/runs/6403930128/job/17383462302
